### PR TITLE
Fixed warnings and added support for skipping nested fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,20 @@ Sets a list of fields to be skipped from testing your callbacks' items. It's use
 For example if you have a field that is always set to `datetime.now()` in your spider, you probably want to add that field to this list to be skipped on tests. Otherwise you'll get a different value when you're generating your fixtures than when you're running your tests, making your tests fail.  
 `Default: []`
 
+**TESTMASTER_SKIPPED_FIELDS_DELIMITER**  
+Used together with `TESTMASTER_SKIPPED_FIELDS_DELIMITER` and meant for nested items.
+e.g. for `item['foo']['bar']`, the value for `TESTMASTER_SKIPPED_FIELDS_DELIMITER` can be 'foo.bar' and `TESTMASTER_SKIPPED_FIELDS_DELIMITER` set to `'.'`  
+`Default: '.'`
+
 **TESTMASTER_REQUEST_SKIPPED_FIELDS**  
 Sets a list of request fields to be skipped when running your tests.  
 Similar to TESTMASTER_SKIPPED_FIELDS but applied to requests instead of items.  
 `Default: []`
+
+**TESTMASTER_REQUEST_SKIPPED_FIELDS_DELIMITER**  
+Used together with `TESTMASTER_REQUEST_SKIPPED_FIELDS` and meant for nested request attributes.
+e.g. for `request.meta['foo']['bar']`, the value for `TESTMASTER_REQUEST_SKIPPED_FIELDS` can be 'meta.foo.bar' and `TESTMASTER_REQUEST_SKIPPED_FIELDS_DELIMITER` set to `'.'`  
+`Default: '.'`
 
 **TESTMASTER_EXCLUDED_HEADERS**  
 Sets a list of headers to exclude from requests recording.  
@@ -244,7 +254,13 @@ Equivalent to global setting.
 **SKIPPED_FIELDS**  
 Equivalent to global setting.
 
+**SKIPPED_FIELDS_DELIMITER**  
+Equivalent to global setting.
+
 **REQUEST_SKIPPED_FIELDS**   
+Equivalent to global setting.
+
+**REQUEST_SKIPPED_FIELDS_DELIMITER**   
 Equivalent to global setting.
 
 **EXCLUDED_HEADERS**   

--- a/scrapy_testmaster/utils.py
+++ b/scrapy_testmaster/utils.py
@@ -21,7 +21,7 @@ from scrapy.utils.conf import (build_component_list, closest_scrapy_cfg,
 from scrapy.utils.misc import arg_to_iter, load_object, walk_modules
 from scrapy.utils.project import get_project_settings
 from scrapy.utils.python import to_bytes
-from scrapy.utils.reqser import request_from_dict
+from scrapy.utils.request import request_from_dict
 from scrapy.utils.spider import iter_spider_classes
 
 from .utils_novel import get_cb_settings, request_to_dict, validate_results
@@ -513,7 +513,7 @@ def generate_test(fixture_path, encoding='utf-8'):
         spider_args_in = data.get(
             'spider_args', data.get('spider_args_in', {}))
         set_spider_attrs(spider, spider_args_in)
-        request = request_from_dict(data['request'], spider)
+        request = request_from_dict(data['request'], spider=spider)
         response_cls = auto_import(data['response'].pop(
             'cls', 'scrapy.http.HtmlResponse'))
         response = response_cls(request=request, **data['response'])

--- a/scrapy_testmaster/utils.py
+++ b/scrapy_testmaster/utils.py
@@ -1,15 +1,15 @@
-import os
-import sys
 import copy
-import zlib
-import pickle
 import json
+import os
+import pickle
 import shutil
+import sys
+import zlib
+from collections.abc import MutableMapping
 from importlib import import_module
 from itertools import islice
 
-from .utils_novel import get_cb_settings, request_to_dict, validate_results
-
+import datadiff.tools
 import six
 from scrapy import signals
 from scrapy.crawler import Crawler
@@ -24,7 +24,7 @@ from scrapy.utils.python import to_bytes
 from scrapy.utils.reqser import request_from_dict
 from scrapy.utils.spider import iter_spider_classes
 
-import datadiff.tools
+from .utils_novel import get_cb_settings, request_to_dict, validate_results
 
 NO_ITEM_MARKER = object()
 FIXTURE_VERSION = 1
@@ -259,6 +259,7 @@ def _process_for_json(data):
             return True
         except:
             return False
+
     to_delete = []
     for k, v in data.items():
         if not _is_jsonable({k: v}):
@@ -298,12 +299,19 @@ def _clean_headers(headers, spider_settings, cb_settings, mode=""):
 # processes request into JSON format for inscribing in view.json and for validation
 def clean_request(request, spider_settings, cb_settings):
     skipped_global = spider_settings.get('TESTMASTER_REQUEST_SKIPPED_FIELDS', default=[])
+
     try:
         skipped_local = cb_settings.REQUEST_SKIPPED_FIELDS
     except AttributeError:
         skipped_local = []
     skipped_fields = skipped_local if skipped_local else skipped_global
-    _clean(request, skipped_fields)
+
+    try:
+        skipped_fields_delimiter = cb_settings.REQUEST_SKIPPED_FIELDS_DELIMITER
+    except AttributeError:
+        skipped_fields_delimiter = spider_settings.get('TESTMASTER_REQUEST_SKIPPED_FIELDS_DELIMITER', default='.')
+
+    _clean(request, skipped_fields, skipped_fields_delimiter)
     request = _decode_dict(request)
     request['headers'] = _clean_headers(request['headers'], spider_settings,
                                         cb_settings, mode="decode")
@@ -320,12 +328,24 @@ def clean_item(item, spider_settings, cb_settings):
         skipped_local = []
     skipped_fields = skipped_local if skipped_local else skipped_global
 
-    _clean(item, skipped_fields)
+    try:
+        skipped_fields_delimiter = cb_settings.SKIPPED_FIELDS_DELIMITER
+    except AttributeError:
+        skipped_fields_delimiter = spider_settings.get('TESTMASTER_SKIPPED_FIELDS_DELIMITER', default='.')
+
+    _clean(item, skipped_fields, skipped_fields_delimiter)
 
 
-def _clean(data, field_list):
+def _clean(data, field_list, skipped_fields_delimiter):
     for field in field_list:
-        data.pop(field, None)
+        field_parts = field.split(skipped_fields_delimiter)
+        item = data
+        for field_part in field_parts[:-1]:
+            if isinstance(item, MutableMapping):
+                item = item.get(field_part) or {}
+
+        if isinstance(item, MutableMapping):
+            item.pop(field_parts[-1], None)
 
 
 def process_result(result, spider_settings, cb_settings):
@@ -532,7 +552,7 @@ def generate_test(fixture_path, encoding='utf-8'):
                 result = mw.process_spider_output(response, result, spider)
 
         for index, (cb_obj, fx_item) in enumerate(six.moves.zip_longest(
-            result, fx_result, fillvalue=NO_ITEM_MARKER
+                result, fx_result, fillvalue=NO_ITEM_MARKER
         )):
             if any(item == NO_ITEM_MARKER for item in (cb_obj, fx_item)):
                 raise AssertionError(
@@ -593,4 +613,5 @@ def generate_test(fixture_path, encoding='utf-8'):
         if not settings.getbool("TESTMASTER_IGNORE_SPIDER_ARGS"):
             self.assertEqual(data['spider_args_out'], result_attr_out,
                              'Output arguments not equal!\nFixture path: %s' % fixture_path)
+
     return test

--- a/scrapy_testmaster/utils_novel.py
+++ b/scrapy_testmaster/utils_novel.py
@@ -1,15 +1,15 @@
-import os
-import shutil
 import importlib
 import inspect
-from glob import glob
-import re
 import json
+import os
+import re
+import shutil
+from glob import glob
 
+from scrapy.exceptions import _InvalidOutput, UsageError
 from scrapy.http import Request
 from scrapy.utils.python import to_unicode
-from scrapy.utils.reqser import request_from_dict, _get_method
-from scrapy.exceptions import _InvalidOutput, UsageError
+from scrapy.utils.request import _get_method, request_from_dict
 
 
 def get_cb_settings(test_dir):
@@ -69,8 +69,11 @@ def get_num_fixtures(test_dir):
 
 def get_fixture_counts(spider_dir, spider, extra_path):
     fixture_counts = {}
-    poss_cb_names = [name for name in dir(spider) if not name.startswith('__') and not
-                     name == "start_requests" and callable(getattr(spider, name))]
+    poss_cb_names = [
+        name for name
+        in dir(spider)
+        if not name.startswith('__') and not name == "start_requests" and callable(getattr(spider, name))
+    ]
     dir_list = os.listdir(spider_dir)
     # assuming extra path in play
     if len(set(dir_list).intersection(set(poss_cb_names))) == 0:
@@ -236,7 +239,7 @@ CURRENT_TESTS = [
 def get_callbacks(spider_path):
     with open(spider_path, 'r') as spider_file:
         text = spider_file.read()
-        callbacks = list(filter(lambda match: not(match.startswith('__') or match == 'start_requests'),
+        callbacks = list(filter(lambda match: not (match.startswith('__') or match == 'start_requests'),
                                 re.findall(r"def\s+(\w+)\([^\n]+response", text)))
         return callbacks
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -18,6 +18,7 @@ class MySpider(scrapy.Spider):
         SPIDER_MIDDLEWARES={{
             'scrapy_testmaster.TestMasterMiddleware': 950,
         }},
+        REQUEST_FINGERPRINTER_IMPLEMENTATION='2.7',
         {custom_settings}
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,16 @@
-import unittest
-
 import copy
 import datetime
+import unittest
 
 from scrapy_testmaster.utils import clean_item, clean_request
 from .shared import Settings
 
 
 class Config1(object):
-    SKIPPED_FIELDS = ["timestamp"]
+    SKIPPED_FIELDS = ["timestamp", "nested/item"]
+    SKIPPED_FIELDS_DELIMITER = "/"
+    REQUEST_SKIPPED_FIELDS = ["meta+nested+item"]
+    REQUEST_SKIPPED_FIELDS_DELIMITER = "+"
 
 
 class Config2(object):
@@ -18,7 +20,13 @@ class Config2(object):
 settings1 = Settings()
 config1 = Config1()
 config2 = Config2()
-cb_obj = {"a": "b", "timestamp": "xyz"}
+cb_obj = {
+    "a": "b",
+    "timestamp": "xyz",
+    "nested": {
+        "item": 20
+    }
+}
 ugly_request = {
     "url": "https://examplewebsite011235811.com",
     "coolkey": b"bytestringexample",
@@ -32,6 +40,9 @@ ugly_request = {
             "splash_headers": {
                 "Authorization": b"Basic auth"
             }
+        },
+        "nested": {
+            "item": 10
         }
     }
 }
@@ -41,7 +52,7 @@ class TestUtils(unittest.TestCase):
     clean_item(cb_obj, settings1, config1)
 
     def test_clean_item(self):
-        self.assertDictEqual(cb_obj, {"a": "b"})
+        self.assertDictEqual(cb_obj, {"a": "b", "nested": {}})
 
     def test_clean_request(self):
         temp_req = copy.deepcopy(ugly_request)
@@ -58,7 +69,8 @@ class TestUtils(unittest.TestCase):
                     "date": str(datetime.date.today()),
                     "splash": {
                         "splash_headers": {}
-                    }
+                    },
+                    "nested": {}
                 }
             })
 
@@ -80,6 +92,9 @@ class TestUtils(unittest.TestCase):
                         "splash_headers": {
                             "Authorization": "Basic auth"
                         }
+                    },
+                    "nested": {
+                        "item": 10
                     }
                 }
             })


### PR DESCRIPTION
- [x] Fixed compatibility with scrapy 2.8.0
- [x] Fixed deprecated imports warning messages
- [x] Added support for skipping nested fields in items and requests 